### PR TITLE
Follow symlinks when looking for machine.

### DIFF
--- a/init/fss2-init-build-env
+++ b/init/fss2-init-build-env
@@ -144,7 +144,7 @@ if [ $result -eq 0 ] ; then
 
   fi
 
-  tmppath="$(find ../meta* -name $MACHINE.conf)"
+  tmppath="$(find -L ../meta* -name $MACHINE.conf)"
   echo "*** $MACHINE.conf found in $tmppath ***"
 
   # 


### PR DESCRIPTION
Allows easier CI testing since the code under test is under
$WORKSPACE and not somewhere that repo puts it.