### PR TITLE
first version for real device

### DIFF
--- a/recipes-core/images/core-image-minimal-initramfs.bbappend
+++ b/recipes-core/images/core-image-minimal-initramfs.bbappend
@@ -1,0 +1,5 @@
+PACKAGE_INSTALL = "u-boot-qoriq busybox udev base-files base-passwd initscripts initramfs-boot keymaps util-linux ${ROOTFS_BOOTSTRAP_INSTALL}"
+
+inherit image_types_uboot
+IMAGE_FSTYPES += "tar.gz ext2.gz ext2.gz.u-boot"
+


### PR DESCRIPTION
add a new core-image-minimal-initramfs.bbappend for customize the initramfs.